### PR TITLE
Fix getColor bug when cannot find keys of color

### DIFF
--- a/src/utils/functions.js
+++ b/src/utils/functions.js
@@ -12,6 +12,8 @@ import { COLORS_PATH } from '@utils/constants';
 export const getColor = (name, palette) => {
   const keys = COLORS_PATH[name] || name;
 
+  if (!keys) return null;
+  
   return palette ?
     getNestedProperty(keys, palette):
     props => getNestedProperty(keys, props.theme.palette);


### PR DESCRIPTION
`getColor` function has to return `null` when it cannot find keys of color.